### PR TITLE
Responsive layout fixes

### DIFF
--- a/app/views/services/accordion.html.erb
+++ b/app/views/services/accordion.html.erb
@@ -8,17 +8,6 @@
   )
 %>
 
-<div class="grid-row">
-  <div class="column-two-thirds">
-    <div class="high-volume">
-      <h3>Hello World</h3>
-    </div>
-  </div>
-  <div class="column-third">
-    <%= render partial: 'govuk_component/related_items', locals: navigation.related_items %>
-  </div>
-</div>
-
 <div class="grid-row child-topic-contents">
   <div class="column-two-thirds">
     <div class="topic-content">
@@ -47,5 +36,9 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <div class="column-third">
+    <%= render partial: 'govuk_component/related_items', locals: navigation.related_items %>
   </div>
 </div>


### PR DESCRIPTION
- Adjust grid layout of main accordion page, move grid elements around so sidebar appears at foot of page on mobile instead of at top

https://trello.com/c/C38c1Ovn/45-detailed-review-of-prototypes-responsive-design
