### PR TITLE
This commit removes the breadcrumbs coming from the taxonomy

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -8,7 +8,7 @@ class ContentItemsController < ApplicationController
       content_html: content_html,
       stylesheet_links_html: stylesheet_links_html,
       main_attributes: main_attributes,
-      breadcrumbs: navigation_helpers.taxon_breadcrumbs[:breadcrumbs],
+      breadcrumbs: navigation_helpers.breadcrumbs[:breadcrumbs],
       taxonomy_sidebar: navigation_helpers.taxonomy_sidebar,
       page_type: page_type,
     }


### PR DESCRIPTION
This is because the Education content is under the Taxonomy but the
learn how to drive is not there yet.