### PR TITLE
Show breadcrumbs from the taxonomy

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -8,7 +8,7 @@ class ContentItemsController < ApplicationController
       content_html: content_html,
       stylesheet_links_html: stylesheet_links_html,
       main_attributes: main_attributes,
-      breadcrumbs: navigation_helpers.breadcrumbs[:breadcrumbs],
+      breadcrumbs: breadcrumbs,
       taxonomy_sidebar: navigation_helpers.taxonomy_sidebar,
       page_type: page_type,
     }
@@ -25,6 +25,14 @@ class ContentItemsController < ApplicationController
   end
 
 private
+
+  def breadcrumbs
+    if SchemaFinderService.taxonomy_supported?(params[:base_path])
+      navigation_helpers.taxon_breadcrumbs[:breadcrumbs]
+    else
+      navigation_helpers.breadcrumbs[:breadcrumbs]
+    end
+  end
 
   def content_html
     # Different rendering apps structure the sidebar differently - try to get the actual content without the sidebar.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,4 +50,8 @@ module ApplicationHelper
     return false if params[:second_level_slug] == "learning-to-drive"
     true
   end
+
+  def hairspace(string)
+    string.gsub(/\s/, "\u200A") # \u200A = unicode hairspace
+  end
 end


### PR DESCRIPTION
Unless the content item is from the learn to drive a car service page.

This commit is to make both `childminder` and `learn how to drive` work
under the prototype

Trello:
https://trello.com/c/jjItBnba/68-fix-the-breadcrumb-for-parenting-childcare-content-in-the-prototype-to-use-topics-instead-of-mainstream-browse

## Screenshots


![screen shot 2017-08-04 at 14 58 36](https://user-images.githubusercontent.com/136777/28971886-9bb5be2c-7925-11e7-98c7-e30846ac8155.png)
![screen shot 2017-08-04 at 14 58 59](https://user-images.githubusercontent.com/136777/28971885-9bb21420-7925-11e7-8246-8f0100808401.png)
![screen shot 2017-08-04 at 14 59 36](https://user-images.githubusercontent.com/136777/28971887-9bbf0018-7925-11e7-84b6-22e76bfc7f9b.png)





