### PR TITLE
Fix running bundle exec rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,6 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'timecop'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -57,6 +59,8 @@ GEM
     builder (3.2.3)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
@@ -84,6 +88,7 @@ GEM
       sass (>= 3.2.0)
     govuk_navigation_helpers (6.0.1)
       gds-api-adapters (~> 42.0)
+    hashdiff (0.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.1)
@@ -120,6 +125,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
     rack-cache (1.7.0)
@@ -179,6 +185,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -202,6 +209,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
+    timecop (0.8.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -212,6 +220,10 @@ GEM
     unicorn (5.3.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webmock (3.0.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -237,11 +249,13 @@ DEPENDENCIES
   sass-rails
   slimmer
   sprockets!
+  timecop
   uglifier
   unicorn
+  webmock
 
 RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
-  require "pry"
-  require "byebug"
-require "webmock"
+require "pry"
 require "timecop"
+require "webmock"
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
We want to add some basic tests to ensure that our prototype works OK.
Unfortunately, running `bundle exec rake` didn't work due to missing
dependencies in the spec_helper.