### PR TITLE
Add non-expanding accordion items

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,9 +69,7 @@ main {
 
 
 .task-list {
-  .subsection {
-    position: relative;
-  }
+  cursor: default;
 
   .subsection-header,
   .subsection-content {
@@ -85,5 +83,31 @@ main {
     @include core-48;
     font-weight: bold;
     color: $black;
+  }
+
+  .subsection {
+    position: relative;
+    cursor: pointer;
+
+    &.subsection-no-expand {
+      cursor: default;
+
+      .subsection-title,
+      .subsection-header,
+      .subsection-header:hover,
+      .subsection-description {
+        cursor: default;
+      }
+
+      .subsection-icon {
+        display: none;
+      }
+
+      .subsection-header {
+        &:hover {
+          background: none;
+        }
+      }
+    }
   }
 }

--- a/app/views/services/accordion.html.erb
+++ b/app/views/services/accordion.html.erb
@@ -12,29 +12,35 @@
   <div class="column-two-thirds">
     <div class="topic-content">
 
-      <div data-module="accordion-with-descriptions" class="js-hidden">
-        <div class="subsection-wrapper task-list">
-
+      <div data-module="accordion-with-descriptions" class="task-list js-hidden">
+        <div class="subsection-wrapper">
           <% page_schema.links.ordered_steps.each_with_index do |group, index| %>
             <% group.each_with_index do |step, step_index| %>
-              <div class="subsection js-subsection" id="index-<%= "#{index}-#{step_index}" %>" data-track-count="accordionSection">
+              <%
+                expandable = true if step.links.ordered_tasks.length > 0
+              %>
+              <div class="subsection <% if expandable %>js-subsection<% else %>subsection-no-expand<% end %>"
+                    id="index-<%= "#{index}-#{step_index}" %>"
+                    data-track-count="accordionSection">
                 <div class="subsection-header js-subsection-header">
-                  <h2 class="subsection-title js-subsection-title">
+                  <h2 class="subsection-title <% if expandable %>js-subsection-title<% end %>">
                     <span class="subsection-number"><%= "#{index + 1 }." %></span>
                     <%= step.title %>
                   </h2>
                   <p class="subsection-description"><%= step.description %></p>
                 </div>
 
-                <div class="subsection-content js-subsection-content" id="subsection_content_<%= "#{index}-#{step_index}" %>">
-                  <ul class="subsection-list">
-                    <% step.links.ordered_tasks.each_with_index do |task, index| %>
-                      <li class="subsection-list-item">
-                        <%= link_to(task.title, task.base_path || task.external_link) %>
-                      </li>
-                    <% end %>
-                  </ul>
-                </div>
+                <% if expandable %>
+                  <div class="subsection-content js-subsection-content" id="subsection_content_<%= "#{index}-#{step_index}" %>">
+                    <ul class="subsection-list">
+                      <% step.links.ordered_tasks.each_with_index do |task, index| %>
+                        <li class="subsection-list-item">
+                          <%= link_to(task.title, task.base_path || task.external_link) %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  </div>
+                <% end %>
               </div>
             <% end %>
           <% end %>


### PR DESCRIPTION
- if there are no links to show in a section, hide the expand/collapse functionality for that section

![screen shot 2017-08-15 at 11 47 41](https://user-images.githubusercontent.com/861310/29313021-9540c05e-81af-11e7-9a6b-a7c82e1a6f1a.png)
