### PR TITLE
Accordion layout tweak

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,6 +76,12 @@ main {
     padding-left: 15%;
   }
 
+  .subsection-header {
+    @include media(tablet) {
+      min-height: 45px;
+    }
+  }
+
   &.js-accordion-with-descriptions .subsection-header {
     border: 0;
   }
@@ -89,9 +95,11 @@ main {
     color: $black;
   }
 
-  .subsection {
-    position: relative;
+  .subsection-border {
     border-top: solid 1px $grey-2;
+  }
+
+  .subsection {
     cursor: pointer;
 
     &.subsection-no-expand {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,6 +76,10 @@ main {
     padding-left: 15%;
   }
 
+  &.js-accordion-with-descriptions .subsection-header {
+    border: 0;
+  }
+
   .subsection-number {
     position: absolute;
     top: 14px;
@@ -87,6 +91,7 @@ main {
 
   .subsection {
     position: relative;
+    border-top: solid 1px $grey-2;
     cursor: pointer;
 
     &.subsection-no-expand {

--- a/app/views/services/accordion.html.erb
+++ b/app/views/services/accordion.html.erb
@@ -15,34 +15,46 @@
       <div data-module="accordion-with-descriptions" class="task-list js-hidden">
         <div class="subsection-wrapper">
           <% page_schema.links.ordered_steps.each_with_index do |group, index| %>
-            <% group.each_with_index do |step, step_index| %>
-              <%
-                expandable = true if step.links.ordered_tasks.length > 0
-              %>
-              <div class="subsection <% if expandable %>js-subsection<% else %>subsection-no-expand<% end %>"
-                    id="index-<%= "#{index}-#{step_index}" %>"
-                    data-track-count="accordionSection">
-                <div class="subsection-header js-subsection-header">
-                  <h2 class="subsection-title <% if expandable %>js-subsection-title<% end %>">
-                    <span class="subsection-number"><%= "#{index + 1 }." %></span>
-                    <%= step.title %>
-                  </h2>
-                  <p class="subsection-description"><%= step.description %></p>
+            <%
+              last_loop_index = nil
+            %>
+            <div class="subsection-border">
+              <% group.each_with_index do |step, step_index| %>
+                <%
+                  expandable = true if step.links.ordered_tasks.length > 0
+                  show_number = true if index != last_loop_index
+                %>
+                <div class="subsection <% if expandable %>js-subsection<% else %>subsection-no-expand<% end %>"
+                      id="index-<%= "#{index}-#{step_index}" %>"
+                      data-track-count="accordionSection">
+                  <div class="subsection-header js-subsection-header">
+                    <h2 class="subsection-title <% if expandable %>js-subsection-title<% end %>">
+                      <% if show_number %>
+                        <span class="subsection-number"><%= "#{index + 1 }." %></span>
+                      <% end %>
+                      <%= step.title %>
+                    </h2>
+                    <p class="subsection-description"><%= step.description %></p>
+                  </div>
+
+                  <% if expandable %>
+                    <div class="subsection-content js-subsection-content" id="subsection_content_<%= "#{index}-#{step_index}" %>">
+                      <ul class="subsection-list">
+                        <% step.links.ordered_tasks.each_with_index do |task, index| %>
+                          <li class="subsection-list-item">
+                            <%= link_to(task.title, task.base_path || task.external_link) %>
+                          </li>
+                        <% end %>
+                      </ul>
+                    </div>
+                  <% end %>
                 </div>
 
-                <% if expandable %>
-                  <div class="subsection-content js-subsection-content" id="subsection_content_<%= "#{index}-#{step_index}" %>">
-                    <ul class="subsection-list">
-                      <% step.links.ordered_tasks.each_with_index do |task, index| %>
-                        <li class="subsection-list-item">
-                          <%= link_to(task.title, task.base_path || task.external_link) %>
-                        </li>
-                      <% end %>
-                    </ul>
-                  </div>
-                <% end %>
-              </div>
-            <% end %>
+                <%
+                  last_loop_index = index
+                %>
+              <% end %>
+            </div>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
- can now have more than one expand/collapse element inside a numbered section of the tasklist

<img width="654" alt="screen shot 2017-08-15 at 15 02 05" src="https://user-images.githubusercontent.com/861310/29319114-bb8104fc-81ca-11e7-8158-88ad69bd7123.png">
