### PR TITLE
Get PDFs working

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -22,7 +22,12 @@ class ContentItemsController < ApplicationController
   # as text/html, not as JSON)
   def fall_through
     bypass_slimmer
-    render html: raw_content_item_html.html_safe
+    if params["format"] == "pdf"
+      pdf = open("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}?cachebust=#{Time.zone.now.to_i}").read
+      send_data pdf, type: :pdf, disposition: :inline
+    else
+      render html: raw_content_item_html.html_safe
+    end
   end
 
 private


### PR DESCRIPTION
PDFs currently render horribly as they're sent as HTML. This fixes that.
A better fix for more formats should be doable after the lab

Browse to /government/uploads/system/uploads/attachment_data/file/381218/Health_20declaration_20booklet.pdf in the prototype to test