### PR TITLE
Allow site search

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,12 +23,6 @@ main {
   -webkit-font-smoothing: antialiased;
 }
 
-.header-wrapper {
-  .site-search {
-    display: none;
-  }
-}
-
 .subsection-content {
   h3 {
     @include bold-24;

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -123,10 +123,10 @@ private
 
   def raw_content_item_html
     @raw_html ||= begin
-      raw_html = open("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}?cachebust=#{Time.zone.now.to_i}",
-        # Ensure we get the new version of the page, which should have all content in a two-thirds column
-        'Cookie' => @cookie_name,
-      ).read
+      uri =  URI.parse("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}")
+      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", "Time.zone.now.to_i"]
+      uri.query = URI.encode_www_form(query_params)
+      raw_html = open(uri.to_s, 'Cookie' => @cookie_name).read
 
 #      request.path == '/' ? edit_home_page_html(raw_html) : raw_html
     end


### PR DESCRIPTION
By dealing with the query params in a better manner we can enable
site search.  This commit appends the cache bust parameter to the query
params so that they work even if there are some already on the URL.