### PR TITLE
Allow standard browse to fall through

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,12 +7,16 @@ Rails.application.routes.draw do
 
   get "/browse.json" => redirect("/api/content/browse")
 
+  get "/browse/childcare-parenting" => redirect("/childcare-parenting")
+  get '/browse/:base_path', to: 'browse#show', base_path: /.*json/
+  get "/browse/:base_path", to: 'content_items#fall_through'
+
   resources :browse, only: [:show], param: :top_level_slug do
     get ':second_level_slug', on: :member, to: "second_level_browse_page#show"
   end
 
   get '/prototype', to: 'welcome#index'
-  get '/*base_path', to: 'taxons#show', constraints: TaxonConstraint.new
+  get '/*base_path', to: 'content_items#fall_through', constraints: TaxonConstraint.new
   get '/*base_path', to: 'content_items#showforms', constraints: FormConstraint.new
   get '/*base_path', to: 'content_items#show', constraints: ContentItemConstraint.new
   get '/*base_path', to: 'content_items#fall_through'


### PR DESCRIPTION
The browse pages are broken at the moment on this prototype.  This at least allows us to get first
level browse pages visible.