### PR TITLE
Add links to the tasklist page to browse

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -37,6 +37,14 @@ class ContentItemsController < ApplicationController
     }
   end
 
+  def browse
+    @cookie_name = "ABTest-EducationNavigation=B"
+    bypass_slimmer
+
+    raw_html = raw_content_item_html
+    render html: edit_browse_page_html(raw_html).html_safe
+  end
+
   # This method is used to display any pages the prototype is not concerned with. It does this by fetching the page
   # from the production site and rendering the response verbatim as HTML.
   # NB: Any **NON-HTML** requests will **STILL BE RETURNED AS HTML**. An example of this is the Miller Columns for
@@ -142,6 +150,21 @@ private
     document = Nokogiri::HTML(html)
     document.at_css('.header-logo a')['href'] = '/'
     update_childcare_and_parenting_on_home_page(document)
+    document.to_html
+  end
+
+  def edit_browse_page_html(html)
+    document = Nokogiri::HTML(html)
+    document.css('.high-volume ol li').last.replace('<li><a href="/services/how-to-become-a-childminder">How to become a childminder</a></li>')
+
+    how_to_object_link = document.at_css('[href="/government/publications/how-to-object-guidance-for-registered-childminders-and-childcare-providers"]')
+
+    if how_to_object_link
+      how_to_object_li = how_to_object_link.ancestors('li').first
+
+      how_to_object_li.add_previous_sibling('<li class="subsection-list-item"><a href="/services/how-to-become-a-childminder">How to become a childminder</a><p>You need to follow this process if you\'re registering as a childminder with Ofsted. You don\'t need to do this if you\'re registering with an agency. The process is different if you\'re in Wales, Scotland or Northern Ireland.</p></li>')
+    end
+
     document.to_html
   end
 

--- a/app/controllers/segment_constraints/browse_constraint.rb
+++ b/app/controllers/segment_constraints/browse_constraint.rb
@@ -1,0 +1,5 @@
+class BrowseConstraint
+  def matches?(request)
+    request.path == "/childcare-parenting/providing-childcare"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   get '/prototype', to: 'welcome#index'
+  get '/*base_path', to: 'content_items#browse', constraints: BrowseConstraint.new
   get '/*base_path', to: 'content_items#fall_through', constraints: TaxonConstraint.new
   get '/*base_path', to: 'content_items#showforms', constraints: FormConstraint.new
   get '/*base_path', to: 'content_items#show', constraints: ContentItemConstraint.new


### PR DESCRIPTION
We want links to our tasklist page to appear in the taxon page for childcare ( https://www.gov.uk/childcare-parenting/providing-childcare )

We replace the last link in the "Most viewed in this topic" section so we
maintain 5 links.  Anymore becomes a bit overwhelming.

The other link ends up eighth in the "Becoming a childcare provider" accordion
section.

Most viewed:
![screen shot 2017-08-29 at 15 43 41](https://user-images.githubusercontent.com/773037/29827095-f02126c2-8cd0-11e7-9c9d-963e91bd04a6.png)

Accordion section:
![screen shot 2017-08-29 at 15 47 06](https://user-images.githubusercontent.com/773037/29827243-588fada0-8cd1-11e7-9a34-d284edff4238.png)



