### PR TITLE
A few fixes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 @import 'modules/prototype';
 @import 'modules/taxons.scss';
 @import 'modules/full-nav';
+@import 'modules/guide';
 
 main {
   @include core-19;

--- a/app/assets/stylesheets/modules/_guide.scss
+++ b/app/assets/stylesheets/modules/_guide.scss
@@ -1,0 +1,65 @@
+
+.part-navigation-container {
+  margin-top: $gutter;
+  margin-bottom: $gutter;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 1.5;
+  }
+
+  border-bottom: 1px solid $grey-2;
+}
+
+.part-navigation {
+  margin-bottom: $gutter / 2;
+  @include core-19;
+
+  @include media(tablet) {
+    @include core-16;
+  }
+
+  li {
+    list-style: none;
+    margin-bottom: 0.75em;
+
+    a {
+      display: block;
+    }
+  }
+}
+
+
+.part-navigation li {
+  list-style: decimal;
+  margin-left: 1.5em;
+  padding-left: 0.3em;
+}
+
+.part-title {
+  @include bold-27;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter-two-thirds;
+  }
+}
+
+.add-title-margin {
+  // @include responsive-top-margin;
+}
+
+
+// FIXME: Remove when typography improvements made to
+//        govspeak component
+//
+// Distinguish between part titles (27px) and h2s
+// within content of part by reducing font-size
+//
+// Override h2 sizes to match layout used by alphagov/frontend
+// https://github.com/alphagov/static/blob/f44470edc4e4159ea37481985c641034741623ac/app/assets/stylesheets/helpers/_text.scss#L38
+.govuk-govspeak {
+  h2 {
+    @include bold-24;
+  }
+}
+

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -130,8 +130,6 @@ private
     main_html.attributes.reduce('') do |attributes, (key, value)|
       attributes + "#{key}=#{value} "
     end
-
-    "class=taxon-page"
   end
 
   def main_html

--- a/app/services/schema_finder_service.rb
+++ b/app/services/schema_finder_service.rb
@@ -62,7 +62,7 @@ class SchemaFinderService
       task["base_path"] == "/#{base_path}"
     end
 
-    task["title"]
+    task["title"] if task
   end
 
   def find_current_step_number(base_path)


### PR DESCRIPTION
The numbered lists at the top of guides look weird, so we're bringing in some of the styling from government-frontend

The class on `main` was hardcoded to `taxon-page` which is wrong,so we allow the page to set its own attributes.  This was causing links on guide pages to appear as block level elements.

On guide parts that are not in our configuration, `task` is `nil`.  We defend against this.