### PR TITLE
Remove link of current step

### DIFF
--- a/app/views/content_items/_full_task_nav.html.erb
+++ b/app/views/content_items/_full_task_nav.html.erb
@@ -35,7 +35,11 @@
                       <ul class="subsection-list">
                         <% step.links.ordered_tasks.each_with_index do |task, index| %>
                           <li class="subsection-list-item">
-                            <%= link_to(task.title, task.base_path || task.external_link) %>
+                            <% if request.path == task.base_path %>
+                              <strong><%= task.title %></strong>
+                            <% else %>
+                              <%= link_to(task.title, task.base_path || task.external_link) %>
+                            <% end %>
                           </li>
                         <% end %>
                       </ul>


### PR DESCRIPTION
People keep navigating back to the step that they're on, so we'll just make it
text.

Don't merge until we get a clear spot