### PR TITLE
Insert a hard coded search result

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'remote-sass'
 gem 'sprockets', github: 'rails/sprockets'
 
 group :development, :test do
+  gem 'capybara'
   gem 'pry'
   gem 'rspec-rails'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,13 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    capybara (2.14.0)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -227,6 +234,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -234,6 +243,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
+  capybara
   dotenv-rails
   foreman
   gds-api-adapters

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,36 @@
+require 'open-uri'
+
+class SearchController < ApplicationController
+  def results
+    bypass_slimmer
+
+    raw_html = raw_content_item_html
+    render html: edit_results_page_html(raw_html).html_safe
+  end
+
+private
+
+  def get_content(uri)
+    open(uri.to_s, 'Cookie' => "ABTest-EducationNavigation=B").read
+  end
+
+  def raw_content_item_html
+    @raw_html ||= begin
+      uri =  URI.parse("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}")
+      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", "Time.zone.now.to_i"]
+      uri.query = URI.encode_www_form(query_params)
+      raw_html = get_content(uri)
+    end
+  end
+
+  def edit_results_page_html(html)
+    document = Nokogiri::HTML(html)
+    document.css('.results-list li').first.add_previous_sibling('<li><h3><a href="/services/how-to-drive-a-car">How to drive a car</a></h3><p>Find out what you need to do to drive a car in the UK.</p></li>')
+
+    document.to_html
+  end
+
+  def bypass_slimmer
+    response.headers[Slimmer::Headers::SKIP_HEADER] = 'true'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   get '/prototype', to: 'welcome#index'
+  get '/search', to: 'search#results'
   get '/*base_path', to: 'content_items#browse', constraints: BrowseConstraint.new
   get '/*base_path', to: 'content_items#fall_through', constraints: TaxonConstraint.new
   get '/*base_path', to: 'content_items#showforms', constraints: FormConstraint.new

--- a/spec/features/fixtures/govuk_search_results.html
+++ b/spec/features/fixtures/govuk_search_results.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><head><title>test - Search - GOV.UK</title></head>
+  <body class="mainstream search">
+    <main id="content" role="main" class="group search">
+    <div class="results-block">
+      <div class="inner-block">
+        <ol class="results-list" id="js-live-search-results">
+          <li>
+            <h3><a href="/check-mot-status">Check the MOT status of a vehicle</a></h3>
+          </li>
+          <li>
+            <h3><a href="/change-driving-test">Change your driving <mark>test</mark> appointment</a></h3>
+          </li>
+          <li>
+            <h3><a href="/book-driving-test">Book your driving <mark>test</mark></a></h3>
+          </li>
+        </ol>
+      </div>
+    </div>
+    </main>
+  </body>
+</html>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'The search page' do
+  let(:search_results_html) { File.read(fixture_file('govuk_search_results.html')) }
+
+  it "should insert the learn to drive item as the first result" do
+    allow_any_instance_of(SearchController).to receive(:get_content).and_return search_results_html
+
+    visit '/search?q=test'
+    first_result_title = page.first("h3").text
+
+    expect(first_result_title).to eq("How to drive a car")
+    expect(page).to have_selector('h3', count: 4)
+  end
+
+  def fixture_file(file)
+    File.expand_path("fixtures/" + file, File.dirname(__FILE__))
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,7 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "spec_helper"
 require "rspec/rails"
+require 'capybara/rails'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
We want to add the learn to drive page as the top result.  We envisage that
any lab search will be roughly in this topic, so it's not too bad.

I've used a direct route as opposed to a constraint (like the others) as this
will only ever apply to the search path.

There is duplication between this and the content_items controller, but for the sake of simplicity,
I'm happy with it.