### PR TITLE
Use frontend toolkit stick at top script [DO NOT MERGE]

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,5 +3,6 @@
 //= require slidy-up
 //= require subsection-view
 //= require accordion-with-descriptions
+//= require stop-scrolling-at-footer
 
-GOVUK.slidyNav.init()
+GOVUK.stickAtTopWhenScrolling.init()

--- a/app/assets/javascripts/slidy-up.js
+++ b/app/assets/javascripts/slidy-up.js
@@ -26,7 +26,7 @@
       return $el.offset()
     },
     init: function () {
-      var $els = $('.js-slidy-stick')
+      var $els = $('.js-stick-at-top-when-scrolling')
 
       if ($els.length > 0) {
         sticky.$els = $els
@@ -66,18 +66,17 @@
       if (sticky._hasScrolled === true) {
         sticky._hasScrolled = false
 
-        var windowVerticalPosition = sticky.getWindowPositions().scrollTop + ($(window).height() * 0.9);
+        var windowVerticalPosition = sticky.getWindowPositions().scrollTop
 
         var windowDimensions = sticky.getWindowDimensions()
 
         sticky.$els.each(function (i, el) {
           var $el = $(el)
           var scrolledFrom = $el.data('scrolled-from')
-          var bottom = $(window).height() - sticky.getElementOffset($el).top - $el.height();
 
-          if (scrolledFrom && windowVerticalPosition > scrolledFrom) {
+          if (scrolledFrom && windowVerticalPosition < scrolledFrom) {
             sticky.release($el)
-          } else if (windowVerticalPosition >= bottom) {
+          } else if (windowDimensions.width > 768 && windowVerticalPosition >= sticky.getElementOffset($el).top) {
             sticky.stick($el)
           }
         })
@@ -100,29 +99,30 @@
             $shim.css('width', elParentWidth)
             $el.css('width', elParentWidth)
           }
+
+          if (windowDimensions.width <= 768) {
+            sticky.release($el)
+          }
         })
       }
     },
     stick: function ($el) {
-      if (!$el.hasClass('slidy-fixed')) {
+      if (!$el.hasClass('content-fixed')) {
         $el.data('scrolled-from', sticky.getElementOffset($el).top)
         var height = Math.max($el.height(), 1)
         var width = $el.width()
         $el.before('<div class="shim" style="width: ' + width + 'px; height: ' + height + 'px">&nbsp;</div>')
-        $el.css('width', width + 'px').addClass('slidy-fixed')
+        $el.css('width', width + 'px').addClass('content-fixed')
       }
     },
     release: function ($el) {
-      $('.slidy-fixed').each(function (i, el) {
-        $el = $(el)
-        if ($el.hasClass('slidy-fixed')) {
-          $el.data('scrolled-from', false)
-          $el.removeClass('slidy-fixed').css('width', '')
-          $el.siblings('.shim').remove()
-        }
-      })
+      if ($el.hasClass('content-fixed')) {
+        $el.data('scrolled-from', false)
+        $el.removeClass('content-fixed').css('width', '')
+        $el.siblings('.shim').remove()
+      }
     }
   }
-  GOVUK.slidyNav = sticky
+  GOVUK.stickAtTopWhenScrolling = sticky
   global.GOVUK = GOVUK
 })(window)

--- a/app/assets/javascripts/stop-scrolling-at-footer.js
+++ b/app/assets/javascripts/stop-scrolling-at-footer.js
@@ -1,0 +1,139 @@
+// Stop scrolling at footer.
+//
+// This can be added to elements with `position: fixed` to stop them from
+// overflowing on the footer.
+//
+// Usage:
+//
+//    GOVUK.stopScrollingAtFooter.addEl($(node), $(node).height());
+//
+// Height is passed in separatly incase the scrolling element has no height
+// itself.
+
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  var stopScrollingAtFooter = {
+    _pollingId: null,
+    _isPolling: false,
+    _hasScrollEvt: false,
+    _els: [],
+
+    addEl: function ($fixedEl, height) {
+      var fixedOffset
+
+      if (!$fixedEl.length) { return }
+
+      fixedOffset = parseInt($fixedEl.css('top'), 10)
+      fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset
+
+      stopScrollingAtFooter.updateFooterTop()
+      $(global).on('govuk.pageSizeChanged', stopScrollingAtFooter.updateFooterTop)
+
+      var $siblingEl = $('<div></div>')
+      $siblingEl.insertBefore($fixedEl)
+      var fixedTop = $siblingEl.offset().top - $siblingEl.position().top
+      $siblingEl.remove()
+
+      var el = {
+        $fixedEl: $fixedEl,
+        height: height + fixedOffset,
+        fixedTop: height + fixedTop,
+        state: 'fixed'
+      }
+      stopScrollingAtFooter._els.push(el)
+
+      stopScrollingAtFooter.initTimeout()
+    },
+    updateFooterTop: function () {
+      var footer = $('.js-footer:eq(0)')
+      if (footer.length === 0) {
+        return 0
+      }
+      stopScrollingAtFooter.footerTop = footer.offset().top - 10
+    },
+    initTimeout: function () {
+      if (stopScrollingAtFooter._hasScrollEvt === false) {
+        $(window).scroll(stopScrollingAtFooter.onScroll)
+        stopScrollingAtFooter._hasScrollEvt = true
+      }
+    },
+    onScroll: function () {
+      if (stopScrollingAtFooter._isPolling === false) {
+        stopScrollingAtFooter.startPolling()
+      }
+    },
+    startPolling: (function () {
+      if (window.requestAnimationFrame) {
+        return function () {
+          var callback = function () {
+            stopScrollingAtFooter.checkScroll()
+            if (stopScrollingAtFooter._isPolling === true) {
+              stopScrollingAtFooter.startPolling()
+            }
+          }
+          stopScrollingAtFooter._pollingId = window.requestAnimationFrame(callback)
+          stopScrollingAtFooter._isPolling = true
+        }
+      } else {
+        return function () {
+          stopScrollingAtFooter._pollingId = window.setInterval(stopScrollingAtFooter.checkScroll, 16)
+          stopScrollingAtFooter._isPolling = true
+        }
+      }
+    }()),
+    stopPolling: (function () {
+      if (window.requestAnimationFrame) {
+        return function () {
+          window.cancelAnimationFrame(stopScrollingAtFooter._pollingId)
+          stopScrollingAtFooter._isPolling = false
+        }
+      } else {
+        return function () {
+          window.clearInterval(stopScrollingAtFooter._pollingId)
+          stopScrollingAtFooter._isPolling = false
+        }
+      }
+    }()),
+    checkScroll: function () {
+      var cachedScrollTop = $(window).scrollTop()
+      if ((cachedScrollTop < (stopScrollingAtFooter.cachedScrollTop + 2)) && (cachedScrollTop > (stopScrollingAtFooter.cachedScrollTop - 2))) {
+        stopScrollingAtFooter.stopPolling()
+        return
+      } else {
+        stopScrollingAtFooter.cachedScrollTop = cachedScrollTop
+      }
+
+      $.each(stopScrollingAtFooter._els, function (i, el) {
+        var bottomOfEl = cachedScrollTop + el.height
+
+        if (bottomOfEl > stopScrollingAtFooter.footerTop) {
+          stopScrollingAtFooter.stick(el)
+        } else {
+          stopScrollingAtFooter.unstick(el)
+        }
+      })
+    },
+    stick: function (el) {
+      if (el.state === 'fixed' && el.$fixedEl.css('position') === 'fixed') {
+        el.$fixedEl.css({ 'position': 'absolute', 'top': stopScrollingAtFooter.footerTop - el.fixedTop })
+        el.state = 'absolute'
+      }
+    },
+    unstick: function (el) {
+      if (el.state === 'absolute') {
+        el.$fixedEl.css({ 'position': '', 'top': '' })
+        el.state = 'fixed'
+      }
+    }
+  }
+
+  GOVUK.stopScrollingAtFooter = stopScrollingAtFooter
+
+  $(global).load(function () { $(global).trigger('govuk.pageSizeChanged') })
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/stylesheets/modules/_sticky-nav.scss
+++ b/app/assets/stylesheets/modules/_sticky-nav.scss
@@ -1,13 +1,18 @@
 .sticky-nav {
   margin-top: 15px;
   background-color: #eee;
+  z-index: 1;
 
   h2 {
     @include bold-24;
   }
 }
 
-.sticky-nav.sticky {
+.content-fixed {
   position: fixed;
   top: 0;
+}
+
+.shim {
+  display: block;
 }

--- a/app/views/content_items/_sticky_nav.html.erb
+++ b/app/views/content_items/_sticky_nav.html.erb
@@ -1,18 +1,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
-    <div class="sticky-nav">
+    <div class="sticky-nav js-stick-at-top-when-scrolling">
       <h2><%= link_to("Learning to drive: step by step", @page_schema.base_path) %></h2>
     </div>
   </div>
 </div>
-
-<script>
-  $(document).ready( function() {
-    var $stickyNav = $(".sticky-nav"),
-        stickyNavTopPosition = $stickyNav.offset().top;
-
-    $(window).scroll( function() {
-      $stickyNav.toggleClass("sticky", window.scrollY >= stickyNavTopPosition);
-    });
-  });
-</script>


### PR DESCRIPTION
The code now uses the sticky script from the frontend toolkit.

I have also added the additional script from the toolkit that stops the sticky nav from showing when it reaches the footer of the page.

NOTE: This doesn't seem to work on mobile.