### PR TITLE
Show nav on secondary content

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -25,7 +25,7 @@ class ContentItemsController < ApplicationController
       current_step_title: schema_finder.find_base_path_title(params[:base_path]),
       current_step_number: step_and_task_numbers[0],
       current_task_number: step_and_task_numbers[1],
-      override_sidebar: task_navigation_service.task_navigation_supported?
+      override_sidebar: task_navigation_service.applicable_content?
     }
   end
 
@@ -45,7 +45,7 @@ class ContentItemsController < ApplicationController
       current_step_title: schema_finder.find_base_path_title(params[:base_path]),
       current_step_number: step_and_task_numbers[0],
       current_task_number: step_and_task_numbers[1],
-      override_sidebar: task_navigation_service.task_navigation_supported?
+      override_sidebar: task_navigation_service.applicable_content?
     }
   end
 
@@ -225,7 +225,7 @@ private
   def task_navigation_service
     TaskNavigationService.new(
       schema_name: schema_finder.name,
-      base_path: params[:base_path]
+      base_path: request.env['content_item'].dig('base_path') || params[:base_path]
     )
   end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -85,17 +85,7 @@ private
   end
 
   def breadcrumbs
-    if task_navigation_service.task_navigation_supported?
-      task_group = task_navigation_service.task_for_page
-
-      [
-        { title: "Home", url: "/" },
-        { title: "Parenting, childcare and children's services", url: "/childcare-parenting"},
-        { title: "Childcare and early years", url: "/childcare-parenting/childcare-and-early-years"},
-        { title: "How to become a childminder", url: "/services/how-to-become-a-childminder" },
-        { title: task_group["title"], url: task_group["base_path"] }
-      ]
-    elsif SchemaFinderService.taxonomy_supported?(params[:base_path])
+    if SchemaFinderService.taxonomy_supported?(params[:base_path])
       navigation_helpers.taxon_breadcrumbs[:breadcrumbs]
     else
       navigation_helpers.breadcrumbs[:breadcrumbs]

--- a/app/services/content_item_mutator.rb
+++ b/app/services/content_item_mutator.rb
@@ -11,7 +11,7 @@ class ContentItemMutator
     mapping = mapping_for(base_path)
     mutated_content_item = content_item.to_hash.merge(mapping)
 
-    if TaskNavigationService.new(base_path: base_path).task_navigation_supported?
+    if TaskNavigationService.new(base_path: base_path).applicable_content?
       mutated_content_item.merge(task_nav(base_path))
     end
   end

--- a/app/services/task_navigation_service.rb
+++ b/app/services/task_navigation_service.rb
@@ -15,7 +15,7 @@ class TaskNavigationService
   end
 
   def is_secondary_content?
-    @base_path.start_with?(*secondary_content)
+    secondary_content.any?{ |path| path.start_with? @base_path }
   end
 
   def navigation_config

--- a/config/task_nav/how-to-become-a-childminder.json
+++ b/config/task_nav/how-to-become-a-childminder.json
@@ -135,6 +135,7 @@
         ]
       ],
       "title": "How to become a childminder"
-    }
+    },
+    "secondary_content":[]
   }
 }

--- a/config/task_nav/how-to-drive-a-car.json
+++ b/config/task_nav/how-to-drive-a-car.json
@@ -173,6 +173,27 @@
           }
         ]
       ]
-    }
+    },
+    "secondary_content": [
+      "/apply-for-your-full-driving-licence",
+      "/complain-about-a-driving-instructor",
+      "/contact-dvsa",
+      "/contact-the-dvla",
+      "/driving-eyesight-rules",
+      "/driving-test-cost",
+      "/dvlaforms",
+      "/government/publications/driving-instructor-grades-explained",
+      "/government/publications/know-your-traffic-signs",
+      "/guidance/rules-for-observing-driving-tests",
+      "/pass-plus",
+      "/report-an-illegal-driving-instructor",
+      "/report-driving-medical-condition",
+      "/seat-belts-law",
+      "/speed-limits",
+      "/speeding-penalties",
+      "/vehicle-insurance",
+      "/vehicles-can-drive",
+      "/view-driving-licence"
+    ]
   }
 }


### PR DESCRIPTION
This will show the sticky nav bar and expandable navigation on pages that are in the `secondary_content` array.  This will include parts in guides and subpages in things like simple smart answers.

(eg https://www.gov.uk/contact-dvsa/y )

We might have to be careful when we do highlighting to show which stage you're on as we'll no longer be able to guarantee that a page is a step in the process.