### PR TITLE
Fix guidance page

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -31,7 +31,7 @@ class ContentItemsController < ApplicationController
 
   def showforms
     @page_schema = schema_finder.page_schema
-    step_and_task_numbers = task_number_for_page.task_number_for_page
+    step_and_task_numbers = task_navigation_service.task_number_for_page
 
     @cookie_name = "ABTest-EducationNavigation=A"
     render :show, locals: {

--- a/app/controllers/segment_constraints/form_constraint.rb
+++ b/app/controllers/segment_constraints/form_constraint.rb
@@ -1,10 +1,11 @@
 class FormConstraint
   def matches?(request)
     content_item = request.env['content_item']
-    content_item && (guidance_content?(content_item))
+    content_item && guidance_content?(content_item)
   end
 
   def guidance_content?(content_item)
-    content_item['navigation_document_supertype'] == 'guidance' && content_item['government_document_supertype'] == 'forms'
+    content_item['navigation_document_supertype'] == 'guidance' &&
+      ['forms', 'guidance'].include?(content_item['government_document_supertype'])
   end
 end


### PR DESCRIPTION
The /government/publications/car-show-me-tell-me-vehicle-safety-questions page
was being rendered by the show action which didn't include enough of the
content.  This should now work.