### PR TITLE
Fix z-index of stickynav on mobile

### DIFF
--- a/app/assets/stylesheets/modules/_sidebar.scss
+++ b/app/assets/stylesheets/modules/_sidebar.scss
@@ -121,7 +121,7 @@
   }
 
   &.sticky {
-    z-index: 1;
+    z-index: 6;
     left: 0;
     width: 100%;
     margin: 0;


### PR DESCRIPTION
There are some instances where the stickynav is scrolling behind certain elements, such as additional tabs on the page. The z-index number has been increased to fix this.