### PR TITLE
highlight "taking driving lessons" on sidebar

### DIFF
--- a/config/services/learn-to-drive-a-car.json
+++ b/config/services/learn-to-drive-a-car.json
@@ -47,7 +47,7 @@
               },
               {
                 "title": "Taking driving lessons",
-                "base_path": "/driving-lessons-learning-to-drive/"
+                "base_path": "/driving-lessons-learning-to-drive"
               },
               {
                 "title": "Find driving schools, lessons and instructors",


### PR DESCRIPTION
This logic relies on the "highlight_sidebar_step?" [helper method](https://github.com/alphagov/govuk-services-prototype/blob/master/app/helpers/application_helper.rb#L25)
Having the extra "/" made the comparison not work.

<img width="389" alt="screen shot 2017-09-06 at 15 37 03" src="https://user-images.githubusercontent.com/136777/30117824-41a821e6-9319-11e7-9848-ae4ea99359ff.png">
