### PR TITLE
Supply default task nav

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -77,6 +77,8 @@ class ContentItemsController < ApplicationController
 private
 
   def task_sidebar
+    return {} unless task_nav
+
     {
       "title" => task_nav["title"],
       "base_path" => task_nav["base_path"],


### PR DESCRIPTION
This breaks content that isn't part of the service unless we allow a default.

(eg https://govuk-services-prototype.herokuapp.com/complain-independent-case-examiner )