### PR TITLE
Reduce title duplication in the code

### DIFF
--- a/app/views/content_items/_sidebar.html.erb
+++ b/app/views/content_items/_sidebar.html.erb
@@ -2,7 +2,7 @@
   <div class="task-list sidebar">
     <div data-module="accordion-with-descriptions">
       <h2>
-        <%= link_to("Learning to drive: step by step", page_schema.base_path) %>
+        <%= link_to(page_schema.title, page_schema.base_path) %>
       </h2>
       <div class="subsection-wrapper">
         <%

--- a/app/views/content_items/_sticky_nav.html.erb
+++ b/app/views/content_items/_sticky_nav.html.erb
@@ -7,7 +7,7 @@
             <g id="icomoon-ignore"></g>
             <path fill="currentColor" d="M333.2 384l169.4-169.4c12.4-12.4 12.4-32.8 0-45.2s-32.8-12.4-45.2 0l-192 192c-12.4 12.4-12.4 32.8 0 45.2l192 192c6.2 6.2 14.4 9.4 22.6 9.4s16.4-3.2 22.6-9.4c12.4-12.4 12.4-32.8 0-45.2l-169.4-169.4z"></path>
           </svg>
-          Learning to drive: step by step
+          <%= page_schema.title %>
         </a>
       </h2>
     </div>

--- a/app/views/content_items/show.html.erb
+++ b/app/views/content_items/show.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if override_sidebar %>
-  <%= render partial: 'sticky_nav' %>
+  <%= render partial: 'sticky_nav', locals: { page_schema: @page_schema } %>
 <% else %>
   <%= render partial: 'govuk_component/breadcrumbs',
       locals: {


### PR DESCRIPTION
To reduce updating the title in several places, it now gets it from the page schema instead.