### PR TITLE
Replace www.gov.uk urls in some pages

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -140,11 +140,10 @@ private
   def raw_content_item_html
     @raw_html ||= begin
       uri =  URI.parse("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}")
-      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", "Time.zone.now.to_i"]
+      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", Time.zone.now.to_i]
       uri.query = URI.encode_www_form(query_params)
       raw_html = open(uri.to_s, 'Cookie' => @cookie_name).read
-
-#      request.path == '/' ? edit_home_page_html(raw_html) : raw_html
+      raw_html.gsub("https://www.gov.uk", "")
     end
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -17,7 +17,7 @@ private
   def raw_content_item_html
     @raw_html ||= begin
       uri =  URI.parse("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}")
-      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", "Time.zone.now.to_i"]
+      query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", Time.zone.now.to_i]
       uri.query = URI.encode_www_form(query_params)
       raw_html = get_content(uri)
     end


### PR DESCRIPTION
We need to replace the links to www.gov.uk where possible.  This doesn't do it
 everywhere, so we might want to use middleware instead.