### PR TITLE
Fix sidebar heading underline bug

### DIFF
--- a/app/assets/stylesheets/modules/_sidebar.scss
+++ b/app/assets/stylesheets/modules/_sidebar.scss
@@ -14,11 +14,11 @@
 
   h2 {
     @include core-24;
-    text-decoration: underline;
 
     a {
       @include core-24;
       font-weight: bold;
+      text-decoration: underline;
     }
   }
 


### PR DESCRIPTION
- fixes this bug in Firefox...

![screen shot 2017-09-07 at 09 22 50](https://user-images.githubusercontent.com/861310/30153340-29248d68-93ae-11e7-80ff-d0fd78a84830.png)
