### PR TITLE
Removes arrow icon

### DIFF
--- a/app/assets/stylesheets/modules/_full-nav.scss
+++ b/app/assets/stylesheets/modules/_full-nav.scss
@@ -88,21 +88,6 @@
 }
 
 .slidy-fixed {
-  .arrow {
-    @include media(tablet) {
-      color: white;
-      float: right;
-      text-decoration: none;
-      background-image: url(image_path('arrow-01.png'));
-      width: 10px;
-      background-size: cover;
-      padding: 12px 15px;
-      background-repeat: no-repeat;
-    }
-  }
-}
-
-.slidy-fixed {
   position: fixed;
   bottom: 0 ;
   z-index: 99999;


### PR DESCRIPTION
This is to bypass error on heroku during deployment, and also because we
not using it anymore

 Sprockets::FileNotFound: could not find file:
/tmp/build_749670de18c7b5817d468634e4c06ff4/alphagov-govuk-services-prototype-f555cfa/app/assets/images/arrow-01.png