### PR TITLE
Design adjustments

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -106,8 +106,8 @@ span.theme-title {
       top: $dottop;
       left: $dotleft;
       margin-top: 1px;
-      margin-left: -2px;
-      width: 4px;
+      margin-left: -0;
+      width: 2px;
       height: 100%;
       background: $grey-3;
       @include core-24;

--- a/app/assets/stylesheets/modules/_sidebar.scss
+++ b/app/assets/stylesheets/modules/_sidebar.scss
@@ -87,6 +87,7 @@
 
   .subsection-header {
     padding-left: 17%;
+    padding-bottom: 10px;
 
     @include media(tablet) {
       min-height: 0;
@@ -125,11 +126,13 @@
   }
 
   .js-accordion-with-descriptions .subsection-is-open .subsection-content {
+    padding-top: 0;
     padding-bottom: $gutter-half;
   }
 
   .subsection-content .subsection-description {
     @include core-16;
+    padding-bottom: 15px;
   }
 
   .subsection-list .subsection-list-item {
@@ -154,4 +157,3 @@
     background: none;
   }
 }
-


### PR DESCRIPTION
> A couple of things — the 16px descriptions on the side nav are likely to confuse users, due to their similarity with the links. Is there some way we could differentiate the two things, possibly by putting more of a gap between the description and the links? and maybe less of a gap between the description and the heading?
> Also, could we make the line between the numbers on the main task page 2px?

Trello: https://trello.com/c/q037UVfL/188-prototype-design-changes