### PR TITLE
Use canonical URLs for collections javascript

### DIFF
--- a/app/views/layouts/collections.html.erb
+++ b/app/views/layouts/collections.html.erb
@@ -4,9 +4,9 @@
     <title><%= yield :title %> - GOV.UK</title>
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
-    <script src="https://rawgit.com/alphagov/collections/master/app/assets/javascripts/support.js"/>
-    <script src="https://rawgit.com/alphagov/collections/master/app/assets/javascripts/modules/current-location.js"/>
-    <script src="https://rawgit.com/alphagov/collections/master/app/assets/javascripts/modules/accordion-with-descriptions.js"></script>
+    <script src="https://rawgit.com/alphagov/collections/79923aefc157d2e8377fe9ade698c3a53af005e0/app/assets/javascripts/support.js"/>
+    <script src="https://rawgit.com/alphagov/collections/79923aefc157d2e8377fe9ade698c3a53af005e0/app/assets/javascripts/modules/current-location.js"/>
+    <script src="https://rawgit.com/alphagov/collections/79923aefc157d2e8377fe9ade698c3a53af005e0/app/assets/javascripts/modules/accordion-with-descriptions.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
This version of the accordion has been removed from collections so the
prototype is broken unless we use a canonical URL.