### PR TITLE
Add Divorce and Civil Partnership into top search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -25,9 +25,50 @@ private
 
   def edit_results_page_html(html)
     document = Nokogiri::HTML(html)
-    document.css('.results-list li').first.add_previous_sibling('<li><h3><a href="/services/learn-to-drive-a-car">Learn to drive a car: step by step</a></h3><p>Check what you need to do to learn to drive.</p></li>')
+
+    add_fake_results(document)
 
     document.to_html
+  end
+
+  def add_fake_results(document)
+    first_element = document.css('.results-list li').first
+
+    if document.text.scan(/\bcar\b/).count > 0
+      first_element.add_previous_sibling(
+        %q{
+          <li>
+            <h3>
+              <a href="/services/learn-to-drive-a-car">
+                Learn to drive a car: step by step
+              </a>
+            </h3>
+            <p>Check what you need to do to learn to drive.</p>
+          </li>
+        }
+      )
+    else
+      first_element.add_previous_sibling(
+        %q{
+          <li>
+            <h3>
+              <a href="/services/get-a-divorce">
+                Get a divorce: step by step
+              </a>
+            </h3>
+            <p>How to file for divorce if you’re in England or Wales.</p>
+          </li>
+          <li>
+            <h3>
+              <a href="/services/end-a-civil-partnership">
+                End a civil partnership: step by step
+              </a>
+            </h3>
+            <p>How to end your civil partnership if you’re in England or Wales.</p>
+          </li>
+        }
+      )
+    end
   end
 
   def bypass_slimmer


### PR DESCRIPTION
This commit adds fake top results, it's also retro-compatible with
"learn to drive a car" and doesn't show it when there are no results
with the word "car".

Trello:
https://trello.com/c/SyVUGTml/298-prototype-make-the-two-new-task-lists-appear-for-any-given-search-term

## Search results
<img width="947" alt="screen shot 2017-11-10 at 15 35 28" src="https://user-images.githubusercontent.com/136777/32665730-3263ffba-c62d-11e7-8334-3da30fca58ca.png">
<img width="924" alt="screen shot 2017-11-10 at 15 35 35" src="https://user-images.githubusercontent.com/136777/32665731-32791aee-c62d-11e7-9ba1-7384ec8240a2.png">
<img width="917" alt="screen shot 2017-11-10 at 15 35 47" src="https://user-images.githubusercontent.com/136777/32665732-328eca4c-c62d-11e7-96c6-3178bf370a12.png">
