### PR TITLE
Remove learn to drive a car from search results

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -33,42 +33,26 @@ private
 
   def add_fake_results(document)
     first_element = document.css('.results-list li').first
-
-    if document.text.scan(/\bcar\b/).count > 0
-      first_element.add_previous_sibling(
-        %q{
-          <li>
-            <h3>
-              <a href="/services/learn-to-drive-a-car">
-                Learn to drive a car: step by step
-              </a>
-            </h3>
-            <p>Check what you need to do to learn to drive.</p>
-          </li>
-        }
-      )
-    else
-      first_element.add_previous_sibling(
-        %q{
-          <li>
-            <h3>
-              <a href="/services/get-a-divorce">
-                Get a divorce: step by step
-              </a>
-            </h3>
-            <p>How to file for divorce if you’re in England or Wales.</p>
-          </li>
-          <li>
-            <h3>
-              <a href="/services/end-a-civil-partnership">
-                End a civil partnership: step by step
-              </a>
-            </h3>
-            <p>How to end your civil partnership if you’re in England or Wales.</p>
-          </li>
-        }
-      )
-    end
+    first_element.add_previous_sibling(
+      %q{
+        <li>
+          <h3>
+            <a href="/services/get-a-divorce">
+              Get a divorce: step by step
+            </a>
+          </h3>
+          <p>How to file for divorce if you’re in England or Wales.</p>
+        </li>
+        <li>
+          <h3>
+            <a href="/services/end-a-civil-partnership">
+              End a civil partnership: step by step
+            </a>
+          </h3>
+          <p>How to end your civil partnership if you’re in England or Wales.</p>
+        </li>
+      }
+    )
   end
 
   def bypass_slimmer


### PR DESCRIPTION
A decision has been made to remove it as it was interfering with certain
searches such as "start a divorce" or "end a marriage".