### PR TITLE
Fix rendering of Browse pages through AJAX request

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,6 @@ Rails.application.routes.draw do
 
   get "/browse.json" => redirect("/api/content/browse")
 
-  get '/browse/:base_path', to: 'browse#show', base_path: /.*json/
-
   resources :browse, only: [:show], param: :top_level_slug do
     get ':second_level_slug', on: :member, to: "second_level_browse_page#show"
   end


### PR DESCRIPTION
This route needs to be removed as the whole logic depends on finding
a browse page by the `params[:top_level_slug]`. What this was doing was
matching a file.json from the `params[:base_path]`, by doing so there
was no `params[:top_level_slug]` so the `/browse` pages where not
working under AJAX request.