### PR TITLE
Make header link point to prototype on load

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,3 +6,7 @@
 //= require govuk-component/tasklist
 
 GOVUK.slidyNav.init()
+
+$(document).ready(function() {
+  $('#logo').attr('href', 'https://govuk-services-prototype.herokuapp.com');
+});


### PR DESCRIPTION
- use JS on page load to switch href attribute of header logo to point to prototype rather than GOV.UK
- really hacky but works