### PR TITLE
Add Child Arrangements Step by Step to Browse

### DIFF
--- a/app/helpers/browse_helper.rb
+++ b/app/helpers/browse_helper.rb
@@ -66,6 +66,17 @@ module BrowseHelper
     OVERRIDE_BROWSE_PAGES[path]
   end
 
+  def override_child_arrangements?
+    "/browse/births-deaths-marriages/marriage-divorce" == path ||
+    "/browse/childcare-parenting/divorce-separation-legal" == path
+  end
+
+  def add_child_arrangements_link?(title)
+    title == "Getting separated or divorced" ||
+      title == "Child maintenance" ||
+      title == "Child custody"
+  end
+
   def path
     "/browse/#{params[:top_level_slug]}/#{params[:second_level_slug]}"
   end

--- a/app/views/second_level_browse_page/_links.html.erb
+++ b/app/views/second_level_browse_page/_links.html.erb
@@ -9,6 +9,12 @@
     <% end %>
 
     <ul>
+      <% if add_child_arrangements_link?(list.title) %>
+        <li>
+          <%= link_to "Make child arrangements: step by step", "/services/make-child-arrangements" %>
+        </li>
+      <% end %>
+
       <% if override_browse_page?(params) && index.zero? %>
         <% override_browse_page_with(params).each do |link| %>
         <li>
@@ -23,6 +29,10 @@
         <% end %>
       <% else %>
         <% list.contents.each_with_index do |list_item, list_index| %>
+          <% if override_child_arrangements? %>
+            <% next if list_item.title == "Making child arrangements if you divorce or separate" %>
+          <% end %>
+
           <% if list_index.zero? && override_divorce_browse_page?(list.title) %>
             <% divorce_service_browse_links.each do |link| %>
             <li>


### PR DESCRIPTION

![screen shot 2017-11-27 at 16 08 20](https://user-images.githubusercontent.com/136777/33276347-402f7ac6-d38d-11e7-8ba1-6ca813abd981.png)

![screen shot 2017-11-27 at 16 09 27](https://user-images.githubusercontent.com/136777/33276412-68bb835e-d38d-11e7-8403-fab8cb6ddf1a.png)



We should add Child Arrangements to:

BROWSE SECTION: Births, deaths, marriages and care
https://www.gov.uk/browse/births-deaths-marriages/marriage-divorce

Add to 'Marriage, civil partnership and divorce'
Under 'Getting separated or divorced' and 'Child maintenance'.
Under 'Child maintenance' we should hide 'Making child arrangements if you divorce or separate'
BROWSE SECTION: Childcare and parenting
https://www.gov.uk/browse/childcare-parenting

Add to 'Divorce, separation and legal issues'
Under 'Child maintenance' and 'Child custody'
Under 'Child maintenance' we should hide 'Making child arrangements if
you divorce or separate'