### PR TITLE
Fall through to GOV.UK for most things

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -9,11 +9,14 @@ class ContentItemsController < ApplicationController
     "png" => :png
   }
 
+  COOKIE_NAME = "ABTest-GetADivorceTaskListSidebar=B; ABTest-GetADivorceTaskListHeader=B;\
+  ABTest-CivilPartnershipTaskListSidebar=B; ABTest-CivilPartnershipTaskListHeader=B".freeze
+
+
   def show
     @page_schema = schema_finder.page_schema
     step_and_task_numbers = task_navigation_service.task_number_for_page
 
-    @cookie_name = "ABTest-GetADivorceTaskListSidebar=B"
     render :show, locals: {
       content_html: content_html,
       stylesheet_links_html: stylesheet_links_html,
@@ -33,7 +36,6 @@ class ContentItemsController < ApplicationController
     @page_schema = schema_finder.page_schema
     step_and_task_numbers = task_navigation_service.task_number_for_page
 
-    @cookie_name = "ABTest-GetADivorceTaskListSidebar=A"
     render :show, locals: {
       content_html: main_html.inner_html.html_safe,
       stylesheet_links_html: stylesheet_links_html,
@@ -50,7 +52,6 @@ class ContentItemsController < ApplicationController
   end
 
   def browse
-    @cookie_name = "ABTest-GetADivorceTaskListSidebar=B"
     bypass_slimmer
 
     raw_html = raw_content_item_html
@@ -63,7 +64,6 @@ class ContentItemsController < ApplicationController
   # the browse pages, which rely on a JSON object being returned (but is currently broken, because the JSON is returned
   # as text/html, not as JSON)
   def fall_through
-    @cookie_name = "ABTest-GetADivorceTaskListSidebar=B"
     bypass_slimmer
 
     if CONTENT_TYPES.keys.include? params["format"]
@@ -142,7 +142,7 @@ private
       uri =  URI.parse("https://#{ENV['GOVUK_APP_DOMAIN']}#{request.fullpath}")
       query_params = URI.decode_www_form(String(uri.query)) << ["cachebust", Time.zone.now.to_i]
       uri.query = URI.encode_www_form(query_params)
-      raw_html = open(uri.to_s, 'Cookie' => @cookie_name).read
+      raw_html = open(uri.to_s, 'Cookie' => COOKIE_NAME).read
       raw_html.gsub("https://www.gov.uk", "")
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   get '/services/get-a-divorce', to: 'services#divorce'
   get '/services/end-a-civil-partnership', to: 'services#civilpartnership'
   get '/services/make-child-arrangements', to: 'services#childarrangements'
+
+  get '/get-a-divorce', to: 'services#divorce'
+  get '/end-a-civil-partnership', to: 'services#civilpartnership'
+
   get '/services/:base_path', to: 'services#show'
   get '/services', to: 'services#index'
 
@@ -16,9 +20,6 @@ Rails.application.routes.draw do
 
   get '/prototype', to: 'welcome#index'
   get '/search', to: 'search#results'
-  get '/*base_path', to: 'content_items#fall_through', constraints: TaxonConstraint.new
-  get '/*base_path', to: 'content_items#showforms', constraints: FormConstraint.new
-  get '/*base_path', to: 'content_items#show', constraints: ContentItemConstraint.new
   get '/*base_path', to: 'content_items#fall_through'
   root to: 'content_items#fall_through'
   post '/:base_path', to: redirect('/%{base_path}/camden')


### PR DESCRIPTION
We set the cookies for the headers and sidebars for get-a-divorce and
end-civil-partnership content to be shown.

At this point we just want to show what's deployed on GOV.UK so we just fall
through to proxying.

We also redirect requests to the task list pages so that the navigation links
work OK.