### PR TITLE
Add sticky header to the prototype [WIP]

### DIFF
--- a/app/assets/javascripts/govuk-component/task-list-header.js
+++ b/app/assets/javascripts/govuk-component/task-list-header.js
@@ -1,3 +1,43 @@
+function makeSticky() {
+  var stickyNavOffset;
+  var resizeTimer;
+
+  var $stickyWrap = $('<div/>').addClass('sticky-wrapper');
+  var $stickyInner = $('<div/>').addClass('sticky-inner');
+  var $header = $('.gem-c-task-list-header');
+  $header.wrap($stickyWrap);
+  $header.wrapInner($stickyInner);
+
+  setStickyOffset();
+  setStickyWrapHeight();
+
+  $(window).scroll(function() {
+    $header.toggleClass("sticky", $(window).scrollTop() >= stickyNavOffset);
+  });
+
+  $(window).resize(function() {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(resize,400);
+  });
+
+  function resize() {
+    setStickyOffset();
+    setStickyWrapHeight();
+  }
+
+  function setStickyOffset() {
+    stickyNavOffset = $header.parent().offset().top;
+  }
+
+  function setStickyWrapHeight() {
+    $header.parent().height($header.outerHeight());
+  }
+}
+
+$(document).ready(function() {
+  makeSticky();
+});
+/* original, proper version as a GOV.UK module...
 (function (Modules) {
   "use strict";
   window.GOVUK = window.GOVUK || {};
@@ -36,3 +76,4 @@
     }
   };
 })(window.GOVUK.Modules);
+*/

--- a/app/assets/stylesheets/modules/sticky.css
+++ b/app/assets/stylesheets/modules/sticky.css
@@ -1,0 +1,27 @@
+.gem-c-task-list-header.sticky {
+  position: fixed;
+  z-index: 100;
+  top: 0;
+  left: 0;
+  width: 100%;
+  //padding: 15px 0;
+  border-top: 0;
+  box-sizing: border-box;
+}
+
+.gem-c-task-list-header .sticky-inner {
+  max-width: 930px;
+  margin: 0 auto;
+}
+
+@media (max-width: 1020px) {
+  .gem-c-task-list-header.sticky .sticky-inner {
+    padding: 0 30px;
+  }
+}
+
+@media (max-width: 641px) {
+  .gem-c-task-list-header.sticky .sticky-inner {
+    padding: 0 15px;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,9 @@ class ApplicationController < ActionController::Base
   def authenticate
     return unless Rails.env.production?
 
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV['USERNAME'] && password == ENV['PASSWORD']
-    end
+    # authenticate_or_request_with_http_basic do |username, password|
+    #   username == ENV['USERNAME'] && password == ENV['PASSWORD']
+    # end
   end
 
   def setup_content_item_and_navigation_helpers(model)

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -179,8 +179,9 @@ private
 
   def add_sticky_nav_functionality(html)
     document = Nokogiri::HTML(html)
-    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="/assets/modules/sticky.css" >')
-    document.at_css('body') << '<script src="/assets/govuk-component/task-list-header.js"/>'
+    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="https://cdn.rawgit.com/alphagov/govuk-services-prototype/eca40904ccb42564b539a387fc73f0cad8d55705/app/assets/stylesheets/modules/sticky.css" >')
+    document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk_publishing_components/62b6dbe49564543f786e66d169c8fc7aa78f18ed/app/assets/javascripts/current-location.js"/>'
+    document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk-services-prototype/4f6c574509db51efbc558f1dbc03db4407a0ccf4/app/assets/javascripts/govuk-component/task-list-header.js"/>'
     document.at_css('.gem-c-task-list-header').attributes['data-module'].value = 'tasklistheader'
     document.to_html
   end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -179,10 +179,16 @@ private
 
   def add_sticky_nav_functionality(html)
     document = Nokogiri::HTML(html)
-    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="https://cdn.rawgit.com/alphagov/govuk-services-prototype/eca40904ccb42564b539a387fc73f0cad8d55705/app/assets/stylesheets/modules/sticky.css" >')
-    document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk_publishing_components/62b6dbe49564543f786e66d169c8fc7aa78f18ed/app/assets/javascripts/current-location.js"/>'
-    document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk-services-prototype/4f6c574509db51efbc558f1dbc03db4407a0ccf4/app/assets/javascripts/govuk-component/task-list-header.js"/>'
-    document.at_css('.gem-c-task-list-header').attributes['data-module'].value = 'tasklistheader'
+
+    tasklistheader = document.at_css('.gem-c-task-list-header')
+
+    if tasklistheader
+      document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="https://cdn.rawgit.com/alphagov/govuk-services-prototype/eca40904ccb42564b539a387fc73f0cad8d55705/app/assets/stylesheets/modules/sticky.css" >')
+      document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk_publishing_components/62b6dbe49564543f786e66d169c8fc7aa78f18ed/app/assets/javascripts/current-location.js"/>'
+      document.at_css('body') << '<script src="https://cdn.rawgit.com/alphagov/govuk-services-prototype/4f6c574509db51efbc558f1dbc03db4407a0ccf4/app/assets/javascripts/govuk-component/task-list-header.js"/>'
+      tasklistheader.attributes['data-module'].value = 'tasklistheader'
+    end
+
     document.to_html
   end
 

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -179,8 +179,8 @@ private
 
   def add_sticky_nav_functionality(html)
     document = Nokogiri::HTML(html)
-    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="example.css" >')
-    document.at_css('script').before('<script src="example.js"/>')
+    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="/assets/modules/sticky.css" >')
+    document.at_css('body') << '<script src="/assets/govuk-component/task-list-header.js"/>'
     document.at_css('.gem-c-task-list-header').attributes['data-module'].value = 'tasklistheader'
     document.to_html
   end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -74,6 +74,14 @@ class ContentItemsController < ApplicationController
     end
   end
 
+  def sticky_nav
+    bypass_slimmer
+
+    raw_html = raw_content_item_html
+
+    render html: add_sticky_nav_functionality(raw_html).html_safe
+  end
+
 private
 
   def task_sidebar
@@ -169,6 +177,14 @@ private
     document.to_html
   end
 
+  def add_sticky_nav_functionality(html)
+    document = Nokogiri::HTML(html)
+    document.at_css('link[rel="stylesheet"]').before('<link rel="stylesheet" href="example.css" >')
+    document.at_css('script').before('<script src="example.js"/>')
+    document.at_css('.gem-c-task-list-header').attributes['data-module'].value = 'tasklistheader'
+    document.to_html
+  end
+
   def update_childcare_and_parenting_on_home_page(document)
     taxon = childcare_parenting_taxon
 
@@ -229,4 +245,6 @@ private
       base_path: request.env['content_item'].dig('base_path') || params[:base_path]
     )
   end
+
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <%= csrf_meta_tags %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_include_tag "application" %>
-    <script src="https://rawgit.com/alphagov/collections/master/app/assets/javascripts/support.js"/>
-    <script src="https://rawgit.com/alphagov/collections/master/app/assets/javascripts/modules/current-location.js"/>
+    <script src="https://cdn.rawgit.com/alphagov/govuk_publishing_components/62b6dbe49564543f786e66d169c8fc7aa78f18ed/app/assets/javascripts/history-support.js"/>
+    <script src="https://cdn.rawgit.com/alphagov/govuk_publishing_components/62b6dbe49564543f786e66d169c8fc7aa78f18ed/app/assets/javascripts/current-location.js"/>
     <%= yield :head %>
   </head>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   get '/prototype', to: 'welcome#index'
   get '/search', to: 'search#results'
-  get '/*base_path', to: 'content_items#fall_through'
-  root to: 'content_items#fall_through'
+  get '/*base_path', to: 'content_items#sticky_nav'
+  root to: 'content_items#sticky_nav'
   post '/:base_path', to: redirect('/%{base_path}/camden')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,6 @@ Rails.application.routes.draw do
   get '/prototype', to: 'welcome#index'
   get '/search', to: 'search#results'
   get '/*base_path', to: 'content_items#sticky_nav'
-  root to: 'content_items#sticky_nav'
+  root to: 'content_items#fall_through'
   post '/:base_path', to: redirect('/%{base_path}/camden')
 end


### PR DESCRIPTION
A script and css link has been added to the page so that the sticky header functionality can be added (paths are to be updated).

In the task list header, The `track-click` module is currently set as the `data-module` attribute. We want to add `tasklistheader` to this but it is likely `data-module` only accepts one value. We will replace `track-click` for now, as it can be added in later once the sticky header code has been implemented.

We also changed the routes so that content pages  will now go to the new action that deals with replacing the data attribute.