### PR TITLE
Disable auth for the DAC visit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,9 +10,9 @@ class ApplicationController < ActionController::Base
   def authenticate
     return unless Rails.env.production?
 
-    authenticate_or_request_with_http_basic do |username, password|
-      username == ENV['USERNAME'] && password == ENV['PASSWORD']
-    end
+    # authenticate_or_request_with_http_basic do |username, password|
+    #   username == ENV['USERNAME'] && password == ENV['PASSWORD']
+    # end
   end
 
   def setup_content_item_and_navigation_helpers(model)


### PR DESCRIPTION
We want to be able to test this without the friction of auth on the prototype.

We will replace this after the assessment.